### PR TITLE
fix: CD設定でデプロイ方法をpeaceiris/actions-gh-pagesに変更。

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -25,7 +25,9 @@ jobs:
         run: yarn build
 
       - name: Deploy
-        run: yarn deploy
-        env:
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/main'
+        with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
 


### PR DESCRIPTION
※CD環境からgh-pagesを実行すると、GitHub Actionsにトークンが渡されなくてデプロイエラーとなるため。