### PR TITLE
ドラ表示牌と裏ドラ表示牌の最大枚数を5枚に修正

### DIFF
--- a/src/components/pai/DoraDisplayPais.tsx
+++ b/src/components/pai/DoraDisplayPais.tsx
@@ -12,11 +12,11 @@ interface DoraDisplayPais {
 /** ドラ表示牌 */
 const DoraDisplayPais = (props: DoraDisplayPais) => {
   const doraDisplayPais =
-    props.doraDisplayPais.length >= 4
+    props.doraDisplayPais.length >= 5
       ? props.doraDisplayPais
       : [
           ...props.doraDisplayPais,
-          ...new Array<string>(4 - props.doraDisplayPais.length).fill("back"),
+          ...new Array<string>(5 - props.doraDisplayPais.length).fill("back"),
         ];
 
   return (

--- a/src/styles/pages/PracticePage.scss
+++ b/src/styles/pages/PracticePage.scss
@@ -43,7 +43,7 @@
 
   margin: 1rem 0;
 
-  background-color: pink;
+  // background-color: pink;
 }
 
 .legal-action {
@@ -149,7 +149,7 @@
   flex-direction: column;
   align-items: center;
 
-  background-color: lightblue;
+  // background-color: lightblue;
 }
 
 .fulo-box {

--- a/src/styles/pages/ResultPage.scss
+++ b/src/styles/pages/ResultPage.scss
@@ -21,7 +21,7 @@
   width: 1000px;
   height: 600px;
 
-  background-color: lightblue;
+  // background-color: lightblue;
 }
 
 .btn-group {

--- a/src/styles/pages/SettingPage.scss
+++ b/src/styles/pages/SettingPage.scss
@@ -28,7 +28,7 @@
     display: flex;
     flex-direction: column;
 
-    background-color: lightgreen;
+    // background-color: lightgreen;
 
     // 萬子
     &__manzu {
@@ -65,7 +65,7 @@
     height: 100px;
     margin: 1rem 0;
 
-    background-color: pink;
+    background-color: lightgray;
   }
 }
 

--- a/src/styles/result/HoraResultDisplay.scss
+++ b/src/styles/result/HoraResultDisplay.scss
@@ -33,7 +33,8 @@
   display: flex;
   height: 324px;
 
-  background-color: lightgreen;
+  // background-color: lightgreen;
+  border: solid 1px params.$color_gray;
   width: 100%;
 }
 


### PR DESCRIPTION
- ドラ表示牌と裏ドラ表示牌の最大枚数を5枚に修正 (カンは最大で4回できることに対応)
- 画面デザインを微修正

close #8 